### PR TITLE
added special Attack and fix level selection

### DIFF
--- a/Assets/Scenes/Levels/Level1.unity
+++ b/Assets/Scenes/Levels/Level1.unity
@@ -324,6 +324,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5189245993031634473, guid: 86309158a0e3b8d42b78452df7a10311, type: 3}
   m_PrefabInstance: {fileID: 947427733}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &972864867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 972864868}
+  - component: {fileID: 972864870}
+  - component: {fileID: 972864869}
+  m_Layer: 0
+  m_Name: VictoryZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &972864868
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972864867}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 110, y: 12, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1320051617}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &972864869
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972864867}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 10, y: 10}
+  m_EdgeRadius: 0
+--- !u!114 &972864870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972864867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49feed15b1a942444bd5c38d41f80af5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &996060431
 GameObject:
   m_ObjectHideFlags: 0
@@ -24729,6 +24799,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 996060432}
+  - {fileID: 972864868}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Levels/Level2.unity
+++ b/Assets/Scenes/Levels/Level2.unity
@@ -183,6 +183,10 @@ PrefabInstance:
       propertyPath: target
       value: 
       objectReference: {fileID: 202368830}
+    - target: {fileID: 4963380235308118391, guid: 75a1b56091c7e0f48a3dc8a8ccef033f, type: 3}
+      propertyPath: m_BodyType
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4963380235308118392, guid: 75a1b56091c7e0f48a3dc8a8ccef033f, type: 3}
       propertyPath: m_Name
       value: Slime (2)
@@ -192,6 +196,11 @@ PrefabInstance:
 --- !u!4 &202368830 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5189245993874426188, guid: 86309158a0e3b8d42b78452df7a10311, type: 3}
+  m_PrefabInstance: {fileID: 1953851246}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &369581908 stripped
+BoxCollider2D:
+  m_CorrespondingSourceObject: {fileID: 5189245993874426189, guid: 86309158a0e3b8d42b78452df7a10311, type: 3}
   m_PrefabInstance: {fileID: 1953851246}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &377813376
@@ -290,6 +299,7 @@ Transform:
   m_Children:
   - {fileID: 1242511365}
   - {fileID: 1546573420}
+  - {fileID: 1883967340}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -49800,6 +49810,76 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 75a1b56091c7e0f48a3dc8a8ccef033f, type: 3}
+--- !u!1 &1883967339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1883967340}
+  - component: {fileID: 1883967342}
+  - component: {fileID: 1883967341}
+  m_Layer: 0
+  m_Name: VictoryZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1883967340
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883967339}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 80, y: 5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 778203396}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1883967341
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883967339}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 10, y: 5}
+  m_EdgeRadius: 0
+--- !u!114 &1883967342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883967339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22d88ca1fe491d24a92fb72f2290861d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1953851246
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -49871,6 +49951,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: -14.3
       objectReference: {fileID: 0}
+    - target: {fileID: 5189245993874426191, guid: 86309158a0e3b8d42b78452df7a10311, type: 3}
+      propertyPath: boxCollider2D
+      value: 
+      objectReference: {fileID: 369581908}
     - target: {fileID: 5189245994337375149, guid: 86309158a0e3b8d42b78452df7a10311, type: 3}
       propertyPath: m_Name
       value: StandardAssets

--- a/Assets/Skripts/Events/LoadLevel.cs
+++ b/Assets/Skripts/Events/LoadLevel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using UnityEngine.SceneManagement;
+
+public class LoadLevel : EventManager.Event<LoadLevel>
+{
+    public string levelName;
+
+    public override void Execute()
+    {
+        try
+        {
+            SceneManager.LoadScene(levelName);
+        }
+        catch (Exception e)
+        {
+            SceneManager.LoadScene("MainMenuScene");
+        }
+    }
+}

--- a/Assets/Skripts/Events/LoadLevel.cs.meta
+++ b/Assets/Skripts/Events/LoadLevel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b35f8c45c1a84abf9a761d1e83790c95
+timeCreated: 1625137696

--- a/Assets/Skripts/Events/PlayerDeath.cs
+++ b/Assets/Skripts/Events/PlayerDeath.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class PlayerDeath : EventManager.Event<PlayerDeath>
 {
@@ -13,11 +14,13 @@ public class PlayerDeath : EventManager.Event<PlayerDeath>
         {
             player.health.Die();
         }
+
         // Lose camera Focus and deactivate input for smooth respawn
         model.virtualCamera.m_Follow = null;
         model.virtualCamera.m_LookAt = null;
         player.controlEnabled = false;
         player.collider2d.enabled = false;
-        EventManager.Schedule<PlayerSpawn>(2);
+        var customEvent = EventManager.Schedule<LoadLevel>(2);
+        customEvent.levelName = SceneManager.GetActiveScene().name;
     }
 }

--- a/Assets/Skripts/Events/PlayerEnteredGoal.cs
+++ b/Assets/Skripts/Events/PlayerEnteredGoal.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class PlayerEnteredGoal : EventManager.Event<PlayerEnteredGoal>
 {
@@ -34,10 +35,26 @@ public class PlayerEnteredGoal : EventManager.Event<PlayerEnteredGoal>
                 t2.Seconds,
                 t2.Milliseconds);
 
-            Debug.Log("####### GEWONNEN #######\n####### Keine neue Bestzeit :-( ####### \n Zeit: " + timeString + "\n Best: " + timeString2 + "\n ");
-
+            Debug.Log("####### GEWONNEN #######\n####### Keine neue Bestzeit :-( ####### \n Zeit: " + timeString +
+                      "\n Best: " + timeString2 + "\n ");
         }
-        
-        EventManager.Schedule<PlayerSpawn>(2);
+
+        var customEvent = EventManager.Schedule<LoadLevel>();
+        var currentLevelName = SceneManager.GetActiveScene().name;
+        if (currentLevelName.ToLower().Contains("level1"))
+        {
+            LevelController.setHighestCompletedLevel(1);
+            customEvent.levelName = "Level2";
+        }
+        else if (currentLevelName.ToLower().Contains("level2"))
+        {
+            LevelController.setHighestCompletedLevel(2);
+            customEvent.levelName = "Level3";
+        }
+        else
+        {
+            LevelController.setHighestCompletedLevel(3);
+            customEvent.levelName = "MainMenuScene";
+        }
     }
 }

--- a/Assets/Skripts/Events/RotateWorld.cs
+++ b/Assets/Skripts/Events/RotateWorld.cs
@@ -9,10 +9,7 @@ public class RotateWorld : EventManager.Event<RotateWorld>
     public override void Execute()
     {
         var player = model.player;
-        player.controlEnabled = false;
         player.invertedMovement = !player.invertedMovement;
         player.spriteRenderer.flipY = !player.spriteRenderer.flipY;
-        
-        EventManager.Schedule<EnablePlayerInput>(2);
     }
 }


### PR DESCRIPTION
Habe vergessen mehrere commits draus zu machen:

- Beim PlayerDeath Event wird nun das ganze Level neu geladen
- Ist der Spieler  im Ziel wird das nächste Level freigeschaltet und geladen (Level3 gibt es noch nicht)
 (im letzten Level wird  dann das Menü geladen)
- Der Slime sollte im Flug nicht mehr zur Seite fliegen können
- Bunny und Slime  nutzen die "attackWithCustomAction" des AttackableAttacker beim landen auf dem Kopf eines Gegners
- Der Rhino nutzt "attackWithCustomAction" des AttackableAttacker beim Sprint auf den Gegner
- Die Spielfigur schweb nicht mehr über dem Boden
