### PR TITLE
Display highscores in main menu level selection

### DIFF
--- a/Assets/Scenes/Menus/MainMenuScene.unity
+++ b/Assets/Scenes/Menus/MainMenuScene.unity
@@ -425,6 +425,85 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5087857396356817497, guid: fe8eb82ae5bb2d348866cdd9e77f6a68, type: 3}
   m_PrefabInstance: {fileID: 102009182}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &162397823
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162397824}
+  - component: {fileID: 162397826}
+  - component: {fileID: 162397825}
+  m_Layer: 5
+  m_Name: Highscore
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &162397824
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162397823}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1438986875}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.0012207031, y: 144}
+  m_SizeDelta: {x: 0, y: -31.6381}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &162397825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162397823}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 239
+    m_Alignment: 7
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: '-'
+--- !u!222 &162397826
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162397823}
+  m_CullTransparentMesh: 1
 --- !u!1 &175164153
 GameObject:
   m_ObjectHideFlags: 0
@@ -536,6 +615,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 390813276}
+  - {fileID: 735008958}
   - {fileID: 1637247070}
   - {fileID: 1176705868}
   m_Father: {fileID: 175164154}
@@ -544,7 +624,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 542, y: 0}
-  m_SizeDelta: {x: 477.355, y: 350.8723}
+  m_SizeDelta: {x: 477.355, y: 582.53}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &189091035
 MonoBehaviour:
@@ -1049,6 +1129,10 @@ MonoBehaviour:
   - {fileID: 1438986874}
   - {fileID: 1817097479}
   - {fileID: 189091033}
+  highscoreDisplays:
+  - {fileID: 162397823}
+  - {fileID: 1696256040}
+  - {fileID: 735008957}
 --- !u!1 &493542971
 GameObject:
   m_ObjectHideFlags: 0
@@ -1245,6 +1329,85 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &735008957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 735008958}
+  - component: {fileID: 735008960}
+  - component: {fileID: 735008959}
+  m_Layer: 5
+  m_Name: Highscore
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &735008958
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735008957}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 189091034}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.0012207031, y: 144}
+  m_SizeDelta: {x: 0, y: -31.635437}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &735008959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735008957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 239
+    m_Alignment: 7
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: '-'
+--- !u!222 &735008960
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735008957}
+  m_CullTransparentMesh: 1
 --- !u!1 &859960638
 GameObject:
   m_ObjectHideFlags: 0
@@ -25691,7 +25854,7 @@ RectTransform:
   m_Children:
   - {fileID: 1996807935}
   m_Father: {fileID: 189091034}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -25986,7 +26149,7 @@ RectTransform:
   m_Children:
   - {fileID: 1023588021}
   m_Father: {fileID: 1817097480}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -26143,7 +26306,7 @@ RectTransform:
   m_Children:
   - {fileID: 1353345130}
   m_Father: {fileID: 1438986875}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -26219,6 +26382,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1977271956}
+  - {fileID: 162397824}
   - {fileID: 1482778335}
   - {fileID: 1371687664}
   m_Father: {fileID: 175164154}
@@ -26227,7 +26391,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -546, y: 0}
-  m_SizeDelta: {x: 477.355, y: 350.8723}
+  m_SizeDelta: {x: 477.355, y: 582.5327}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1438986876
 MonoBehaviour:
@@ -26619,12 +26783,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1438986875}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 119.34, y: 48.041077}
-  m_SizeDelta: {x: 159.3604, y: 196.0822}
+  m_AnchoredPosition: {x: 119.34, y: 114.2298}
+  m_SizeDelta: {x: 159.3604, y: 220.903}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1482778336
 MonoBehaviour:
@@ -26773,12 +26937,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 189091034}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 119.34, y: 48.041077}
-  m_SizeDelta: {x: 159.3604, y: 196.0822}
+  m_AnchoredPosition: {x: 119.34, y: 114.2298}
+  m_SizeDelta: {x: 159.3604, y: 220.903}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1637247071
 MonoBehaviour:
@@ -26848,12 +27012,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1817097480}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 119.34, y: 48.041077}
-  m_SizeDelta: {x: 159.3604, y: 196.0822}
+  m_AnchoredPosition: {x: 119.34, y: 114.2298}
+  m_SizeDelta: {x: 159.3604, y: 220.903}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1646029081
 MonoBehaviour:
@@ -26892,6 +27056,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1646029079}
+  m_CullTransparentMesh: 1
+--- !u!1 &1696256040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1696256041}
+  - component: {fileID: 1696256043}
+  - component: {fileID: 1696256042}
+  m_Layer: 5
+  m_Name: Highscore
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1696256041
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696256040}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1817097480}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.0012207031, y: 144}
+  m_SizeDelta: {x: 0, y: -31.635437}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1696256042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696256040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 239
+    m_Alignment: 7
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: '-'
+--- !u!222 &1696256043
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696256040}
   m_CullTransparentMesh: 1
 --- !u!1 &1731937949
 GameObject:
@@ -27285,6 +27528,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 42331959}
+  - {fileID: 1696256041}
   - {fileID: 1646029080}
   - {fileID: 1285272583}
   m_Father: {fileID: 175164154}
@@ -27293,7 +27537,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 477.355, y: 350.8723}
+  m_SizeDelta: {x: 477.355, y: 582.53}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1817097481
 MonoBehaviour:

--- a/Assets/Skripts/Highscore/HighscoreController.cs
+++ b/Assets/Skripts/Highscore/HighscoreController.cs
@@ -76,7 +76,7 @@ public class HighscoreController : MonoBehaviour
     /// <summary>
     /// Reads the Highscore TimeSpan for a specific level. Return the TimeSpan.Zero,
     /// </summary>
-    public TimeSpan GetSavedHighScoreForLevelByName(string level)
+    public static TimeSpan GetSavedHighScoreForLevelByName(string level)
     {
         try
         {

--- a/Assets/Skripts/UI/MainMenuScript.cs
+++ b/Assets/Skripts/UI/MainMenuScript.cs
@@ -1,7 +1,7 @@
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 
 /**
  * Main Menu Script
@@ -12,10 +12,12 @@ public class MainMenuScript : MonoBehaviour
     public GameObject mainMenu;
     public GameObject levelSelection;
     public GameObject[] levels;
+    public GameObject[] highscoreDisplays;
 
     // Setup dynamic parts of the menu
     public void Start() {
         updateDisabledLevels();
+        updateHighscores();
     }
 
     // Enable all levels in the level selection screen that the user has unlocked
@@ -26,6 +28,15 @@ public class MainMenuScript : MonoBehaviour
             if (levels.Length > i) {
                 levels[i].transform.Find("Disabled").gameObject.SetActive(false);
                 Debug.Log("Enabling Level" + (i + 1));
+            }
+        }
+    }
+
+    private void updateHighscores() {
+        for(int i = 0; i < highscoreDisplays.Length; i++) {
+            TimeSpan highscore = HighscoreController.GetSavedHighScoreForLevelByName("Level" + (i + 1));
+            if (highscore != TimeSpan.Zero) {
+                highscoreDisplays[i].GetComponent<Text>().text = highscore.ToString(@"mm\:ss");
             }
         }
     }


### PR DESCRIPTION
Displays the level highscores in the main menu level selection.

<img width="509" alt="Screenshot 2021-07-07 at 17 25 19" src="https://user-images.githubusercontent.com/10333196/124786978-734d0980-df48-11eb-92ec-d67019411e36.png">

Levels that don't have a highscore yet will instead show "-"